### PR TITLE
feat: add user menu theme toggle

### DIFF
--- a/frontendv2/components/TheHeader.vue
+++ b/frontendv2/components/TheHeader.vue
@@ -156,7 +156,7 @@
                   Mes listes
                 </NuxtLink>
                 <div v-if="authStore.isAdmin" class="border-t border-gray-200 dark:border-gray-700 mt-2 pt-2">
-                  <NuxtLink 
+                  <NuxtLink
                     to="/admin"
                     class="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
                     @click="showUserMenu = false"
@@ -166,7 +166,16 @@
                   </NuxtLink>
                 </div>
                 <div class="border-t border-gray-200 dark:border-gray-700 mt-2 pt-2">
-                  <button 
+                  <button
+                    @click="toggleTheme"
+                    class="flex items-center w-full px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
+                  >
+                    <Icon :name="isDark ? 'heroicons:sun' : 'heroicons:moon'" class="w-4 h-4 mr-2" />
+                    {{ isDark ? 'Passer en mode clair' : 'Passer en mode sombre' }}
+                  </button>
+                </div>
+                <div class="border-t border-gray-200 dark:border-gray-700 mt-2 pt-2">
+                  <button
                     @click="handleLogout"
                     class="flex items-center w-full px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"
                   >
@@ -288,6 +297,14 @@ const hideImage = (event: Event) => {
 watch(() => useRoute().path, () => {
   showMobileMenu.value = false
 })
+
+// Theme handling
+const colorMode = useColorMode()
+const isDark = computed(() => colorMode.value === 'dark')
+const toggleTheme = () => {
+  colorMode.preference = isDark.value ? 'light' : 'dark'
+  showUserMenu.value = false
+}
 </script>
 
 <style scoped>

--- a/frontendv2/nuxt.config.ts
+++ b/frontendv2/nuxt.config.ts
@@ -2,9 +2,10 @@
 export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: [
-    '@nuxtjs/tailwindcss', 
+    '@nuxtjs/tailwindcss',
     '@pinia/nuxt',
-    '@vueuse/nuxt'
+    '@vueuse/nuxt',
+    '@nuxtjs/color-mode'
   ],
   css: ['~/assets/css/globals.css'],
   runtimeConfig: {


### PR DESCRIPTION
## Summary
- enable Nuxt color mode module for theme switching
- add light/dark theme toggle in user dropdown menu

## Testing
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9699fe2c83259ca63ef9a25299cf