### PR TITLE
feat(frontendv2): enable dynamic heroicons

### DIFF
--- a/frontendv2/components/global/Icon.vue
+++ b/frontendv2/components/global/Icon.vue
@@ -51,138 +51,50 @@ const iconStyles = computed(() => {
   return props.color ? { color: props.color } : {}
 })
 
+// Automatically resolve Heroicons on demand. This keeps the bundle small
+// while allowing any icon from the library to be used without manually
+// maintaining a mapping list.
+const icons24Outline = import.meta.glob('@heroicons/vue/24/outline/*Icon.js')
+const icons24Solid = import.meta.glob('@heroicons/vue/24/solid/*Icon.js')
+const icons20Solid = import.meta.glob('@heroicons/vue/20/solid/*Icon.js')
+
+function toPascalCase(str: string) {
+  return str
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')
+}
+
 const iconComponent = computed(() => {
-  if (props.name.startsWith('heroicons:')) {
-    const iconName = props.name.replace('heroicons:', '')
-    const variant = props.variant === 'mini' ? '20' : '24'
-    const style = props.variant === 'solid' ? 'solid' : 'outline'
-    
-    // Minimal icon mapping - only icons actually used in the codebase
-    const iconMap: Record<string, any> = {
-      // Navigation & Arrows
-      'arrow-left': () => import('@heroicons/vue/24/outline/ArrowLeftIcon.js'),
-      'arrow-right': () => import('@heroicons/vue/24/outline/ArrowRightIcon.js'),
-      'arrow-up': () => import('@heroicons/vue/24/outline/ArrowUpIcon.js'),
-      'chevron-left': () => import('@heroicons/vue/24/outline/ChevronLeftIcon.js'),
-      'chevron-right': () => import('@heroicons/vue/24/outline/ChevronRightIcon.js'),
-      'chevron-up': () => import('@heroicons/vue/24/outline/ChevronUpIcon.js'),
-      'chevron-down': () => import('@heroicons/vue/24/outline/ChevronDownIcon.js'),
-      'chevron-up-down': () => import('@heroicons/vue/24/outline/ChevronUpDownIcon.js'),
-      
-      // Media & Content
-      'film': () => import('@heroicons/vue/24/outline/FilmIcon.js'),
-      'tv': () => import('@heroicons/vue/24/outline/TvIcon.js'),
-      'photo': () => import('@heroicons/vue/24/outline/PhotoIcon.js'),
-      'book-open': () => import('@heroicons/vue/24/outline/BookOpenIcon.js'),
-      'play': () => import('@heroicons/vue/24/outline/PlayIcon.js'),
-      'document-text': () => import('@heroicons/vue/24/outline/DocumentTextIcon.js'),
-      
-      // User & Account
-      'user': () => import('@heroicons/vue/24/outline/UserIcon.js'),
-      'user-circle': () => import('@heroicons/vue/24/outline/UserCircleIcon.js'),
-      'user-plus': () => import('@heroicons/vue/24/outline/UserPlusIcon.js'),
-      'user-minus': () => import('@heroicons/vue/24/outline/UserMinusIcon.js'),
-      
-      // Interactions
-      'heart': () => import('@heroicons/vue/24/outline/HeartIcon.js'),
-      'heart-solid': () => import('@heroicons/vue/24/solid/HeartIcon.js'),
-      'star': () => import('@heroicons/vue/24/outline/StarIcon.js'),
-      'star-solid': () => import('@heroicons/vue/24/solid/StarIcon.js'),
-      'eye': () => import('@heroicons/vue/24/outline/EyeIcon.js'),
-      'eye-slash': () => import('@heroicons/vue/24/outline/EyeSlashIcon.js'),
-      'share': () => import('@heroicons/vue/24/outline/ShareIcon.js'),
-      'bookmark': () => import('@heroicons/vue/24/outline/BookmarkIcon.js'),
-      'bookmark-solid': () => import('@heroicons/vue/24/solid/BookmarkIcon.js'),
-      
-      // Interface Elements
-      'x-mark': () => import('@heroicons/vue/24/outline/XMarkIcon.js'),
-      'plus': () => import('@heroicons/vue/24/outline/PlusIcon.js'),
-      'magnifying-glass': () => import('@heroicons/vue/24/outline/MagnifyingGlassIcon.js'),
-      'funnel': () => import('@heroicons/vue/24/outline/FunnelIcon.js'),
-      'bars-3': () => import('@heroicons/vue/24/outline/Bars3Icon.js'),
-      'ellipsis-horizontal': () => import('@heroicons/vue/24/outline/EllipsisHorizontalIcon.js'),
-      'ellipsis-vertical': () => import('@heroicons/vue/24/outline/EllipsisVerticalIcon.js'),
-      'cog-6-tooth': () => import('@heroicons/vue/24/outline/Cog6ToothIcon.js'),
-      
-      // Status & Alerts
-      'check': () => import('@heroicons/vue/24/outline/CheckIcon.js'),
-      'check-circle': () => import('@heroicons/vue/24/outline/CheckCircleIcon.js'),
-      'check-badge-solid': () => import('@heroicons/vue/24/solid/CheckBadgeIcon.js'),
-      'exclamation-triangle': () => import('@heroicons/vue/24/outline/ExclamationTriangleIcon.js'),
-      'exclamation-circle': () => import('@heroicons/vue/24/outline/ExclamationCircleIcon.js'),
-      'information-circle': () => import('@heroicons/vue/24/outline/InformationCircleIcon.js'),
-      'x-circle': () => import('@heroicons/vue/24/outline/XCircleIcon.js'),
-      
-      // Theme & Display
-      'sun': () => import('@heroicons/vue/24/outline/SunIcon.js'),
-      'moon': () => import('@heroicons/vue/24/outline/MoonIcon.js'),
-      'computer-desktop': () => import('@heroicons/vue/24/outline/ComputerDesktopIcon.js'),
-      
-      // Communication
-      'chat-bubble-left': () => import('@heroicons/vue/24/outline/ChatBubbleLeftIcon.js'),
-      'chat-bubble-left-ellipsis': () => import('@heroicons/vue/24/outline/ChatBubbleLeftEllipsisIcon.js'),
-      'chat-bubble-oval-left': () => import('@heroicons/vue/24/outline/ChatBubbleOvalLeftIcon.js'),
-      'at-symbol': () => import('@heroicons/vue/24/outline/AtSymbolIcon.js'),
-      
-      // Time & Calendar
-      'calendar': () => import('@heroicons/vue/24/outline/CalendarIcon.js'),
-      'calendar-days': () => import('@heroicons/vue/24/outline/CalendarDaysIcon.js'),
-      'clock': () => import('@heroicons/vue/24/outline/ClockIcon.js'),
-      
-      // Actions
-      'arrow-path': () => import('@heroicons/vue/24/outline/ArrowPathIcon.js'),
-      'arrow-down-tray': () => import('@heroicons/vue/24/outline/ArrowDownTrayIcon.js'),
-      'arrow-top-right-on-square': () => import('@heroicons/vue/24/outline/ArrowTopRightOnSquareIcon.js'),
-      'link': () => import('@heroicons/vue/24/outline/LinkIcon.js'),
-      'printer': () => import('@heroicons/vue/24/outline/PrinterIcon.js'),
-      
-      // Tags & Organization
-      'tag': () => import('@heroicons/vue/24/outline/TagIcon.js'),
-      'hashtag': () => import('@heroicons/vue/24/outline/HashtagIcon.js'),
-      'folder': () => import('@heroicons/vue/24/outline/FolderIcon.js'),
-      
-      // Location & Building
-      'globe-alt': () => import('@heroicons/vue/24/outline/GlobeAltIcon.js'),
-      'building-office': () => import('@heroicons/vue/24/outline/BuildingOfficeIcon.js'),
-      'home': () => import('@heroicons/vue/24/outline/HomeIcon.js'),
-      'map-pin': () => import('@heroicons/vue/24/outline/MapPinIcon.js'),
-      
-      // Development
-      'code-bracket': () => import('@heroicons/vue/24/outline/CodeBracketIcon.js'),
-      'command-line': () => import('@heroicons/vue/24/outline/CommandLineIcon.js'),
-      
-      // Sorting & Filtering
-      'bars-arrow-down': () => import('@heroicons/vue/24/outline/BarsArrowDownIcon.js'),
-      
-      // Account Actions
-      'arrow-right-on-rectangle': () => import('@heroicons/vue/24/outline/ArrowRightOnRectangleIcon.js'),
-      'key': () => import('@heroicons/vue/24/outline/KeyIcon.js'),
-      'identification': () => import('@heroicons/vue/24/outline/IdentificationIcon.js'),
-      'envelope': () => import('@heroicons/vue/24/outline/EnvelopeIcon.js'),
-      'lock-closed': () => import('@heroicons/vue/24/outline/LockClosedIcon.js'),
-      'phone': () => import('@heroicons/vue/24/outline/PhoneIcon.js'),
-      
-      // Admin & Management
-      'pencil-square': () => import('@heroicons/vue/24/outline/PencilSquareIcon.js'),
-      'trash': () => import('@heroicons/vue/24/outline/TrashIcon.js'),
-      'adjustments-horizontal': () => import('@heroicons/vue/24/outline/AdjustmentsHorizontalIcon.js'),
-      'squares-2x2': () => import('@heroicons/vue/24/outline/Squares2X2Icon.js'),
-      'list-bullet': () => import('@heroicons/vue/24/outline/ListBulletIcon.js'),
-      'table-cells': () => import('@heroicons/vue/24/outline/TableCellsIcon.js')
-    }
-    
-    try {
-      const iconImport = iconMap[iconName]
-      if (iconImport) {
-        return defineAsyncComponent(iconImport)
-      }
-    } catch (error) {
-      console.warn(`Icon not found: ${iconName}`)
-    }
-    
-    return null
+  if (!props.name.startsWith('heroicons:')) return null
+
+  let iconName = props.name.replace('heroicons:', '')
+  let variant = props.variant
+
+  if (iconName.endsWith('-solid')) {
+    iconName = iconName.replace('-solid', '')
+    variant = 'solid'
   }
-  
+
+  const size = variant === 'mini' ? '20' : '24'
+  const style = variant === 'solid' || variant === 'mini' ? 'solid' : 'outline'
+
+  const fileName = `${toPascalCase(iconName)}Icon.js`
+  const collection =
+    size === '20'
+      ? icons20Solid
+      : style === 'solid'
+        ? icons24Solid
+        : icons24Outline
+
+  const path = Object.keys(collection).find(p => p.endsWith(`/${fileName}`))
+  const importer = path ? collection[path] : undefined
+
+  if (importer) {
+    return defineAsyncComponent(importer as any)
+  }
+
+  console.warn(`Icon not found: ${iconName}`)
   return null
 })
 


### PR DESCRIPTION
## Summary
- resolve heroicons dynamically using Vite glob imports
- allow any `heroicons:*` icon without maintaining a static map

## Testing
- `npm --prefix frontendv2 test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc095478083258a2d37ea9fe8ac6a