### PR TITLE
Fix search bar debounce to prevent call stack overflow

### DIFF
--- a/frontendv2/components/SearchBar.vue
+++ b/frontendv2/components/SearchBar.vue
@@ -15,7 +15,6 @@
                focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500
                hover:border-primary-400 transition-all duration-200
                shadow-sm hover:shadow-md focus:shadow-lg"
-        @input="onInput"
         @focus="handleFocus"
         @blur="hideSuggestions"
         @keydown.escape="clearSearch"
@@ -247,7 +246,6 @@ onMounted(() => {
 
 // Debounced search implementation
 let searchTimeout: ReturnType<typeof setTimeout> | null = null
-
 const performAutocomplete = async (searchQuery: string) => {
   if (searchQuery.length < 2) {
     suggestions.value = []
@@ -301,16 +299,16 @@ const performAutocomplete = async (searchQuery: string) => {
   }
 }
 
-const onInput = () => {
+watch(query, (newQuery) => {
   selectedSuggestionIndex.value = -1
   if (searchTimeout) {
     clearTimeout(searchTimeout)
   }
-  const searchQuery = query.value
+  const searchQuery = newQuery
   searchTimeout = setTimeout(() => {
     performAutocomplete(searchQuery)
   }, 300)
-}
+})
 
 const handleFocus = () => {
   showSuggestions.value = true

--- a/frontendv2/components/ui/Button.vue
+++ b/frontendv2/components/ui/Button.vue
@@ -74,7 +74,7 @@ const props = withDefaults(defineProps<Props>(), {
   rounded: false
 })
 
-const emit = defineEmits<Emits>()
+const emitEvent = defineEmits<Emits>()
 
 // Determine component tag
 const tag = computed(() => {
@@ -218,7 +218,7 @@ const handleClick = (event: MouseEvent) => {
     event.preventDefault()
     return
   }
-  emit('click', event)
+  emitEvent('click', event)
 }
 </script>
 


### PR DESCRIPTION
## Summary
- debounce search query changes with a watcher instead of input events to avoid recursive updates
- rename emit handler in Button component to prevent stack overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae1c89389c8325bcad7ece741a6a3f